### PR TITLE
Implement crude sessions/speakers flow & data retrieval

### DIFF
--- a/src/Conference.Maui/AppShell.xaml.cs
+++ b/src/Conference.Maui/AppShell.xaml.cs
@@ -1,9 +1,14 @@
-﻿namespace Conference.Maui;
+﻿using Conference.Maui.Pages;
+
+namespace Conference.Maui;
 
 public partial class AppShell : Shell
 {
     public AppShell()
     {
         InitializeComponent();
+
+        Routing.RegisterRoute("SessionDetails", typeof(SessionDetailsPage));
+        Routing.RegisterRoute("SpeakerDetails", typeof(SpeakerDetailsPage));
     }
 }

--- a/src/Conference.Maui/Conference.Maui.csproj
+++ b/src/Conference.Maui/Conference.Maui.csproj
@@ -62,6 +62,7 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+		<PackageReference Include="Sessionize.Api.Client" Version="1.1.0" />
 	</ItemGroup>
 
 	<!-- Localization -->

--- a/src/Conference.Maui/Conference.Maui.csproj
+++ b/src/Conference.Maui/Conference.Maui.csproj
@@ -82,10 +82,4 @@
 	  </EmbeddedResource>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <MauiXaml Update="Pages\SpeakersPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
-
 </Project>

--- a/src/Conference.Maui/Conference.Maui.csproj
+++ b/src/Conference.Maui/Conference.Maui.csproj
@@ -59,6 +59,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Maui" Version="9.0.3" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.90" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />

--- a/src/Conference.Maui/Interfaces/IEventDataService.cs
+++ b/src/Conference.Maui/Interfaces/IEventDataService.cs
@@ -5,4 +5,6 @@ namespace Conference.Maui.Interfaces;
 public interface IEventDataService
 {
     Task<List<Session>> GetAllSessions();
+
+    Task<List<Speaker>> GetAllSpeakers();
 }

--- a/src/Conference.Maui/Interfaces/IEventDataService.cs
+++ b/src/Conference.Maui/Interfaces/IEventDataService.cs
@@ -1,0 +1,8 @@
+﻿using Conference.Maui.Models;
+
+namespace Conference.Maui.Interfaces;
+
+public interface IEventDataService
+{
+    Task<List<Session>> GetAllSessions();
+}

--- a/src/Conference.Maui/MauiProgram.cs
+++ b/src/Conference.Maui/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Conference.Maui.Interfaces;
+﻿using CommunityToolkit.Maui;
+using Conference.Maui.Interfaces;
 using Conference.Maui.Pages;
 using Conference.Maui.Services;
 using Conference.Maui.ViewModels;
@@ -17,7 +18,8 @@ public static class MauiProgram
             {
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-            });
+            })
+            .UseMauiCommunityToolkit();
 
         // TODO I don't think HttpClientFactory is great for mobile...?
         builder.Services.AddHttpClient();

--- a/src/Conference.Maui/MauiProgram.cs
+++ b/src/Conference.Maui/MauiProgram.cs
@@ -25,6 +25,9 @@ public static class MauiProgram
         builder.Services.AddTransient<ScheduleViewModel>();
         builder.Services.AddTransient<SchedulePage>();
 
+        builder.Services.AddTransient<SpeakersViewModel>();
+        builder.Services.AddTransient<SpeakersPage>();
+
 #if DEBUG
         builder.Logging.AddDebug();
 #endif

--- a/src/Conference.Maui/MauiProgram.cs
+++ b/src/Conference.Maui/MauiProgram.cs
@@ -24,11 +24,18 @@ public static class MauiProgram
         // TODO I don't think HttpClientFactory is great for mobile...?
         builder.Services.AddHttpClient();
         builder.Services.AddSingleton<IEventDataService, SessionizeService>();
+        
         builder.Services.AddTransient<ScheduleViewModel>();
         builder.Services.AddTransient<SchedulePage>();
 
         builder.Services.AddTransient<SpeakersViewModel>();
         builder.Services.AddTransient<SpeakersPage>();
+
+        builder.Services.AddTransient<SessionDetailsViewModel>();
+        builder.Services.AddTransient<SessionDetailsPage>();
+
+        builder.Services.AddTransient<SpeakerDetailsViewModel>();
+        builder.Services.AddTransient<SpeakerDetailsPage>();
 
 #if DEBUG
         builder.Logging.AddDebug();

--- a/src/Conference.Maui/MauiProgram.cs
+++ b/src/Conference.Maui/MauiProgram.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Conference.Maui.Interfaces;
+using Conference.Maui.Pages;
+using Conference.Maui.Services;
+using Conference.Maui.ViewModels;
+using Microsoft.Extensions.Logging;
 
 namespace Conference.Maui;
 
@@ -15,8 +19,14 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
 
+        // TODO I don't think HttpClientFactory is great for mobile...?
+        builder.Services.AddHttpClient();
+        builder.Services.AddSingleton<IEventDataService, SessionizeService>();
+        builder.Services.AddTransient<ScheduleViewModel>();
+        builder.Services.AddTransient<SchedulePage>();
+
 #if DEBUG
-		builder.Logging.AddDebug();
+        builder.Logging.AddDebug();
 #endif
 
         return builder.Build();

--- a/src/Conference.Maui/Models/Session.cs
+++ b/src/Conference.Maui/Models/Session.cs
@@ -1,0 +1,30 @@
+﻿namespace Conference.Maui.Models;
+
+public class Session
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Description { get; set; } = string.Empty;
+
+    public DateTimeOffset StartsAt { get; set; }
+
+    public DateTimeOffset EndsAt { get; set; }
+
+    public bool IsServiceSession { get; set; }
+
+    public bool IsPlenumSession { get; set; }
+
+    public int RoomId { get; set; }
+
+    public string Room { get; set; } = string.Empty;
+
+    public string Status { get; set; } = string.Empty;
+
+    public bool IsInformed { get; set; }
+
+    public bool IsConfirmed { get; set; }
+
+    public List<Speaker> Speakers { get; set; } = [];
+}

--- a/src/Conference.Maui/Models/Session.cs
+++ b/src/Conference.Maui/Models/Session.cs
@@ -12,6 +12,8 @@ public class Session
 
     public DateTimeOffset EndsAt { get; set; }
 
+    public int DurationInMinutes => (int)EndsAt.Subtract(StartsAt).TotalMinutes;
+
     public bool IsServiceSession { get; set; }
 
     public bool IsPlenumSession { get; set; }

--- a/src/Conference.Maui/Models/Speaker.cs
+++ b/src/Conference.Maui/Models/Speaker.cs
@@ -1,0 +1,8 @@
+﻿namespace Conference.Maui.Models;
+
+public class Speaker
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Conference.Maui/Models/Speaker.cs
+++ b/src/Conference.Maui/Models/Speaker.cs
@@ -2,7 +2,21 @@
 
 public class Speaker
 {
-    public string Id { get; set; } = string.Empty;
+    public Guid Id { get; set; }
 
-    public string Name { get; set; } = string.Empty;
+    public string FirstName { get; set; } = string.Empty;
+
+    public string LastName { get; set; } = string.Empty;
+
+    public string FullName => $"{FirstName} {LastName}";
+
+    public string Bio { get; set; } = string.Empty;
+
+    public string TagLine { get; set; } = string.Empty;
+
+    public string ProfilePictureUrl { get; set; } = string.Empty;
+
+    public bool IsTopSpeaker { get; set; }
+
+    public List<Session> Sessions { get; set; } = [];
 }

--- a/src/Conference.Maui/Pages/SchedulePage.xaml
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
+             xmlns:models="clr-namespace:Conference.Maui.Models"
+             x:DataType="viewmodels:ScheduleViewModel"
              x:Class="Conference.Maui.Pages.SchedulePage">
-    <VerticalStackLayout>
-        <Label 
-            Text="Welcome to .NET MAUI!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
-    </VerticalStackLayout>
+    <CollectionView ItemsSource="{Binding Sessions}">
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="models:Session">
+                <VerticalStackLayout Margin="10">
+                    <Label Text="{Binding Title}" FontAttributes="Bold" FontSize="32" />
+                    <Label Text="{Binding Description}" />
+                </VerticalStackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/src/Conference.Maui/Pages/SchedulePage.xaml
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
              xmlns:models="clr-namespace:Conference.Maui.Models"
              x:DataType="viewmodels:ScheduleViewModel"
@@ -8,10 +9,15 @@
     <CollectionView ItemsSource="{Binding Sessions}">
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="models:Session">
-                <VerticalStackLayout Margin="10">
-                    <Label Text="{Binding Title}" FontAttributes="Bold" FontSize="24" />
-                    <Label Text="{Binding Description}" MaxLines="3" />
-                </VerticalStackLayout>
+                <Grid Margin="10" RowDefinitions="*,*" ColumnDefinitions="50,*" ColumnSpacing="10">
+                    <Grid.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:ScheduleViewModel}}, Path=GoToSessionDetailsCommand}" CommandParameter="{Binding .}" />
+                    </Grid.GestureRecognizers>
+                    <toolkit:AvatarView Grid.Column="0" Grid.RowSpan="2" ImageSource="{Binding Speakers[0].ProfilePictureUrl}" />
+
+                    <Label Grid.Row="0" Grid.Column="1" Text="{Binding Title}" FontAttributes="Bold" FontSize="18" MaxLines="1" LineBreakMode="TailTruncation" />
+                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding Description}" MaxLines="3" LineBreakMode="TailTruncation" />
+                </Grid>
             </DataTemplate>
         </CollectionView.ItemTemplate>
     </CollectionView>

--- a/src/Conference.Maui/Pages/SchedulePage.xaml
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml
@@ -9,8 +9,8 @@
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="models:Session">
                 <VerticalStackLayout Margin="10">
-                    <Label Text="{Binding Title}" FontAttributes="Bold" FontSize="32" />
-                    <Label Text="{Binding Description}" />
+                    <Label Text="{Binding Title}" FontAttributes="Bold" FontSize="24" />
+                    <Label Text="{Binding Description}" MaxLines="3" />
                 </VerticalStackLayout>
             </DataTemplate>
         </CollectionView.ItemTemplate>

--- a/src/Conference.Maui/Pages/SchedulePage.xaml.cs
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml.cs
@@ -1,9 +1,21 @@
+using Conference.Maui.ViewModels;
+
 namespace Conference.Maui.Pages;
 
 public partial class SchedulePage : ContentPage
 {
-	public SchedulePage()
+	private readonly ScheduleViewModel _viewModel;
+
+	public SchedulePage(ScheduleViewModel scheduleViewModel)
 	{
 		InitializeComponent();
+
+        _viewModel = scheduleViewModel;
+        BindingContext = _viewModel;
 	}
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        await _viewModel.LoadEventData();
+    }
 }

--- a/src/Conference.Maui/Pages/SessionDetailsPage.xaml
+++ b/src/Conference.Maui/Pages/SessionDetailsPage.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:models="clr-namespace:Conference.Maui.Models"
+             xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
+             x:DataType="viewmodels:SessionDetailsViewModel"
+             x:Class="Conference.Maui.Pages.SessionDetailsPage"
+             Title="{Binding SelectedSession.Title}">
+    <VerticalStackLayout Margin="10" Spacing="10">
+        <HorizontalStackLayout BindableLayout.ItemsSource="{Binding SelectedSession.Speakers}"
+                               HorizontalOptions="Center">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="models:Speaker">
+                    <VerticalStackLayout>
+                        <VerticalStackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:SessionDetailsViewModel}}, Path=GoToSpeakerDetailsCommand}" CommandParameter="{Binding .}" />
+                        </VerticalStackLayout.GestureRecognizers>
+                        
+                        <toolkit:AvatarView ImageSource="{Binding ProfilePictureUrl}" />
+                        <Label Text="{Binding FullName}" />
+                    </VerticalStackLayout>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </HorizontalStackLayout>
+
+        <Label Text="{Binding SelectedSession.Room}" FontAttributes="Bold" HorizontalOptions="Center" />
+
+        <Label HorizontalOptions="Center">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="{Binding SelectedSession.StartsAt, StringFormat='{0:dddd, d MMMM HH:mm }'}" />
+                    <Span Text="{Binding SelectedSession.DurationInMinutes, StringFormat='({0} minutes)'}" />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+
+        <Label 
+            Text="{Binding SelectedSession.Description}"
+            VerticalOptions="Center" 
+            HorizontalOptions="Center" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Conference.Maui/Pages/SessionDetailsPage.xaml.cs
+++ b/src/Conference.Maui/Pages/SessionDetailsPage.xaml.cs
@@ -1,0 +1,13 @@
+using Conference.Maui.ViewModels;
+
+namespace Conference.Maui.Pages;
+
+public partial class SessionDetailsPage : ContentPage
+{
+	public SessionDetailsPage(SessionDetailsViewModel sessionDetailsViewModel)
+	{
+		InitializeComponent();
+
+		BindingContext = sessionDetailsViewModel;
+	}
+}

--- a/src/Conference.Maui/Pages/SpeakerDetailsPage.xaml
+++ b/src/Conference.Maui/Pages/SpeakerDetailsPage.xaml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:models="clr-namespace:Conference.Maui.Models"
+             xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
+             xmlns:localization="clr-namespace:Conference.Maui.Resources.Strings"
+             x:DataType="viewmodels:SpeakerDetailsViewModel"
+             x:Class="Conference.Maui.Pages.SpeakerDetailsPage"
+             Title="{Binding SelectedSpeaker.FullName}">
+    <VerticalStackLayout Margin="10" Spacing="10">
+        <toolkit:AvatarView ImageSource="{Binding SelectedSpeaker.ProfilePictureUrl}" />
+
+        <Label Text="{Binding SelectedSpeaker.TagLine}" HorizontalOptions="Center" />
+
+        <Label 
+            Text="{Binding SelectedSpeaker.Bio}"
+            HorizontalOptions="Center" />
+
+        <Label Text="{x:Static localization:Strings.SessionsAtThisEventHeader}" FontAttributes="Bold" />
+        
+        <HorizontalStackLayout BindableLayout.ItemsSource="{Binding SelectedSpeaker.Sessions}">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="models:Session">
+                    <!-- TODO make pretty -->
+                    <Label Text="{Binding Title}" />
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </HorizontalStackLayout>
+    </VerticalStackLayout>
+</ContentPage>

--- a/src/Conference.Maui/Pages/SpeakerDetailsPage.xaml.cs
+++ b/src/Conference.Maui/Pages/SpeakerDetailsPage.xaml.cs
@@ -1,0 +1,13 @@
+using Conference.Maui.ViewModels;
+
+namespace Conference.Maui.Pages;
+
+public partial class SpeakerDetailsPage : ContentPage
+{
+	public SpeakerDetailsPage(SpeakerDetailsViewModel speakerDetailsViewModel)
+	{
+		InitializeComponent();
+
+		BindingContext = speakerDetailsViewModel;
+	}
+}

--- a/src/Conference.Maui/Pages/SpeakersPage.xaml
+++ b/src/Conference.Maui/Pages/SpeakersPage.xaml
@@ -10,9 +10,12 @@
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="models:Speaker">
                 <Grid Margin="10" RowDefinitions="*,*" ColumnDefinitions="50,*" ColumnSpacing="10">
+                    <Grid.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:SpeakersViewModel}}, Path=GoToSpeakerDetailsCommand}" CommandParameter="{Binding .}" />
+                    </Grid.GestureRecognizers>
                     
                     <toolkit:AvatarView Grid.Column="0" Grid.RowSpan="2" ImageSource="{Binding ProfilePictureUrl}" />
-                    <Label Grid.Row="0" Grid.Column="1" Text="{Binding FullName}" FontAttributes="Bold" FontSize="24" />
+                    <Label Grid.Row="0" Grid.Column="1" Text="{Binding FullName}" FontAttributes="Bold" FontSize="18" />
                     <Label Grid.Row="1" Grid.Column="1" Text="{Binding TagLine}" MaxLines="3" />
                 </Grid>
             </DataTemplate>

--- a/src/Conference.Maui/Pages/SpeakersPage.xaml
+++ b/src/Conference.Maui/Pages/SpeakersPage.xaml
@@ -1,11 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
+             xmlns:models="clr-namespace:Conference.Maui.Models"
+             x:DataType="viewmodels:SpeakersViewModel"
              x:Class="Conference.Maui.Pages.SpeakersPage">
-    <VerticalStackLayout>
-        <Label 
-            Text="Welcome to .NET MAUI!"
-            VerticalOptions="Center" 
-            HorizontalOptions="Center" />
-    </VerticalStackLayout>
+    <CollectionView ItemsSource="{Binding Speakers}">
+        <CollectionView.ItemTemplate>
+            <DataTemplate x:DataType="models:Speaker">
+                <Grid Margin="10" RowDefinitions="*,*" ColumnDefinitions="50,*" ColumnSpacing="10">
+                    <Image Grid.Column="0" Grid.RowSpan="2" Source="{Binding ProfilePictureUrl}" />
+                    <Label Grid.Row="0" Grid.Column="1" Text="{Binding FullName}" FontAttributes="Bold" FontSize="24" />
+                    <Label Grid.Row="1" Grid.Column="1" Text="{Binding TagLine}" MaxLines="3" />
+                </Grid>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
 </ContentPage>

--- a/src/Conference.Maui/Pages/SpeakersPage.xaml
+++ b/src/Conference.Maui/Pages/SpeakersPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
              xmlns:models="clr-namespace:Conference.Maui.Models"
              x:DataType="viewmodels:SpeakersViewModel"
@@ -9,7 +10,8 @@
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="models:Speaker">
                 <Grid Margin="10" RowDefinitions="*,*" ColumnDefinitions="50,*" ColumnSpacing="10">
-                    <Image Grid.Column="0" Grid.RowSpan="2" Source="{Binding ProfilePictureUrl}" />
+                    
+                    <toolkit:AvatarView Grid.Column="0" Grid.RowSpan="2" ImageSource="{Binding ProfilePictureUrl}" />
                     <Label Grid.Row="0" Grid.Column="1" Text="{Binding FullName}" FontAttributes="Bold" FontSize="24" />
                     <Label Grid.Row="1" Grid.Column="1" Text="{Binding TagLine}" MaxLines="3" />
                 </Grid>

--- a/src/Conference.Maui/Pages/SpeakersPage.xaml.cs
+++ b/src/Conference.Maui/Pages/SpeakersPage.xaml.cs
@@ -1,9 +1,20 @@
+using Conference.Maui.ViewModels;
+
 namespace Conference.Maui.Pages;
 
 public partial class SpeakersPage : ContentPage
 {
-	public SpeakersPage()
+    private readonly SpeakersViewModel _viewModel;
+
+    public SpeakersPage(SpeakersViewModel speakersViewModel)
 	{
 		InitializeComponent();
-	}
+        _viewModel = speakersViewModel;
+        BindingContext = _viewModel;
+    }
+
+    protected override async void OnNavigatedTo(NavigatedToEventArgs args)
+    {
+        await _viewModel.LoadSpeakersData();
+    }
 }

--- a/src/Conference.Maui/Resources/Strings/Strings.Designer.cs
+++ b/src/Conference.Maui/Resources/Strings/Strings.Designer.cs
@@ -124,6 +124,15 @@ namespace Conference.Maui.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sessions at this event.
+        /// </summary>
+        internal static string SessionsAtThisEventHeader {
+            get {
+                return ResourceManager.GetString("SessionsAtThisEventHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Speakers.
         /// </summary>
         internal static string SpeakersPageTitle {

--- a/src/Conference.Maui/Resources/Strings/Strings.resx
+++ b/src/Conference.Maui/Resources/Strings/Strings.resx
@@ -161,4 +161,8 @@
     <value>About</value>
     <comment>Title for the about page</comment>
   </data>
+  <data name="SessionsAtThisEventHeader" xml:space="preserve">
+    <value>Sessions at this event</value>
+    <comment>On the speaker details page shown as a header above the sessions this speaker has at this event</comment>
+  </data>
 </root>

--- a/src/Conference.Maui/Services/SessionizeService.cs
+++ b/src/Conference.Maui/Services/SessionizeService.cs
@@ -20,6 +20,23 @@ public class SessionizeService : IEventDataService
         }));
     }
 
+    public async Task<List<Speaker>> GetAllSpeakers()
+    {
+        var remoteSpeakers = await _sessionizeClient.GetSpeakersListAsync();
+
+        return remoteSpeakers.Select(speaker => new Speaker
+        {
+            Bio = speaker.Bio,
+            FirstName = speaker.FirstName,
+            Id = speaker.Id,
+            IsTopSpeaker = speaker.IsTopSpeaker,
+            LastName = speaker.LastName,
+            ProfilePictureUrl = speaker.ProfilePicture,
+            TagLine = speaker.TagLine,
+            //Sessions = speaker.Sessions,
+        }).ToList();
+    }
+
     public async Task<List<Session>> GetAllSessions()
     {
         // TODO what are groups in Sessionize?
@@ -38,8 +55,9 @@ public class SessionizeService : IEventDataService
             Room = session.Room,
             Speakers = session.Speakers.Select(speaker => new Speaker
             {
-                Id = speaker.Id,
-                Name = speaker.Name,
+                // TODO first only get minimal info?
+                Id = Guid.Parse(speaker.Id),
+                FirstName = speaker.Name,
             }).ToList(),
             StartsAt = session.StartsAt,
             Status = session.Status,

--- a/src/Conference.Maui/Services/SessionizeService.cs
+++ b/src/Conference.Maui/Services/SessionizeService.cs
@@ -1,0 +1,49 @@
+﻿using Conference.Maui.Interfaces;
+using Conference.Maui.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Sessionize.Api.Client;
+using Sessionize.Api.Client.Configuration;
+
+namespace Conference.Maui.Services;
+
+public class SessionizeService : IEventDataService
+{
+    private readonly SessionizeApiClient _sessionizeClient;
+
+    public SessionizeService(IHttpClientFactory httpClientFactory, ILogger<SessionizeApiClient> logger)
+    {
+        _sessionizeClient = new SessionizeApiClient(httpClientFactory, logger, Options.Create(new SessionizeConfiguration
+        {
+            ApiId = "8cknf5zh",
+            BaseUrl = "https://sessionize.com"
+        }));
+    }
+
+    public async Task<List<Session>> GetAllSessions()
+    {
+        // TODO what are groups in Sessionize?
+        var remoteSessions = await _sessionizeClient.GetSessionsListAsync();
+
+        return remoteSessions.FirstOrDefault()?.Sessions.Select(session => new Session
+        {
+            Description = session.Description ?? string.Empty,
+            EndsAt = session.EndsAt,
+            Id = session.Id,
+            IsConfirmed = session.IsConfirmed,
+            IsInformed = session.IsInformed,
+            IsPlenumSession = session.IsPlenumSession,
+            IsServiceSession = session.IsServiceSession,
+            RoomId = session.RoomId,
+            Room = session.Room,
+            Speakers = session.Speakers.Select(speaker => new Speaker
+            {
+                Id = speaker.Id,
+                Name = speaker.Name,
+            }).ToList(),
+            StartsAt = session.StartsAt,
+            Status = session.Status,
+            Title = session.Title,
+        }).ToList() ?? [];
+    }
+}

--- a/src/Conference.Maui/ViewModels/ScheduleViewModel.cs
+++ b/src/Conference.Maui/ViewModels/ScheduleViewModel.cs
@@ -1,7 +1,24 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Conference.Maui.Interfaces;
+using Conference.Maui.Models;
+using System.Collections.ObjectModel;
 
 namespace Conference.Maui.ViewModels;
 
-public partial class ScheduleViewModel : ObservableObject
+public partial class ScheduleViewModel(IEventDataService eventDataService) : ObservableObject
 {
+    private readonly IEventDataService _eventService = eventDataService;
+
+    public ObservableCollection<Session> Sessions { get; set; } = [];
+
+    public async Task LoadEventData()
+    {
+        var sessions = await _eventService.GetAllSessions();
+
+        Sessions.Clear();
+        foreach (var session in sessions)
+        {
+            Sessions.Add(session);
+        }
+    }
 }

--- a/src/Conference.Maui/ViewModels/ScheduleViewModel.cs
+++ b/src/Conference.Maui/ViewModels/ScheduleViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Conference.Maui.Interfaces;
 using Conference.Maui.Models;
 using System.Collections.ObjectModel;
@@ -20,5 +21,12 @@ public partial class ScheduleViewModel(IEventDataService eventDataService) : Obs
         {
             Sessions.Add(session);
         }
+    }
+
+    [RelayCommand]
+    private async Task GoToSessionDetails(Session selectedSession)
+    {
+        await Shell.Current.GoToAsync("SessionDetails",
+            new Dictionary<string, object> { { "SelectedSession", selectedSession } });
     }
 }

--- a/src/Conference.Maui/ViewModels/SessionDetailsViewModel.cs
+++ b/src/Conference.Maui/ViewModels/SessionDetailsViewModel.cs
@@ -1,0 +1,19 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Conference.Maui.Models;
+
+namespace Conference.Maui.ViewModels;
+
+[QueryProperty(nameof(SelectedSession), nameof(SelectedSession))]
+public partial class SessionDetailsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    Session? _selectedSession;
+
+    [RelayCommand]
+    private async Task GoToSpeakerDetails(Speaker selectedSpeaker)
+    {
+        await Shell.Current.GoToAsync("SpeakerDetails",
+            new Dictionary<string, object> { { "SelectedSpeaker", selectedSpeaker } });
+    }
+}

--- a/src/Conference.Maui/ViewModels/SpeakerDetailsViewModel.cs
+++ b/src/Conference.Maui/ViewModels/SpeakerDetailsViewModel.cs
@@ -1,0 +1,11 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Conference.Maui.Models;
+
+namespace Conference.Maui.ViewModels;
+
+[QueryProperty(nameof(SelectedSpeaker), nameof(SelectedSpeaker))]
+public partial class SpeakerDetailsViewModel : ObservableObject
+{
+    [ObservableProperty]
+    Speaker? _selectedSpeaker;
+}

--- a/src/Conference.Maui/ViewModels/SpeakersViewModel.cs
+++ b/src/Conference.Maui/ViewModels/SpeakersViewModel.cs
@@ -1,0 +1,24 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Conference.Maui.Interfaces;
+using Conference.Maui.Models;
+using System.Collections.ObjectModel;
+
+namespace Conference.Maui.ViewModels;
+
+public partial class SpeakersViewModel(IEventDataService eventDataService) : ObservableObject
+{
+    private readonly IEventDataService _eventService = eventDataService;
+
+    public ObservableCollection<Speaker> Speakers { get; set; } = [];
+
+    public async Task LoadSpeakersData()
+    {
+        var speakers = await _eventService.GetAllSpeakers();
+
+        Speakers.Clear();
+        foreach (var speaker in speakers)
+        {
+            Speakers.Add(speaker);
+        }
+    }
+}

--- a/src/Conference.Maui/ViewModels/SpeakersViewModel.cs
+++ b/src/Conference.Maui/ViewModels/SpeakersViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Conference.Maui.Interfaces;
 using Conference.Maui.Models;
 using System.Collections.ObjectModel;
@@ -20,5 +21,12 @@ public partial class SpeakersViewModel(IEventDataService eventDataService) : Obs
         {
             Speakers.Add(speaker);
         }
+    }
+
+    [RelayCommand]
+    private async Task GoToSpeakerDetails(Speaker selectedSpeaker)
+    {
+        await Shell.Current.GoToAsync("SpeakerDetails",
+            new Dictionary<string, object> { { "SelectedSpeaker", selectedSpeaker } });
     }
 }


### PR DESCRIPTION
This PR implements the data retrieval from Sessionize, currently through the Sessionize API client using the .NET MAUI day Sessionize data.

Also, this adds a crude flow for showing the sessions and tapping through to the speakers.

Lots of work still to be done, but its a start!