### PR TITLE
Remove weird binding of Speaker profile image

### DIFF
--- a/src/Conference.Maui/Conference.Maui.csproj
+++ b/src/Conference.Maui/Conference.Maui.csproj
@@ -26,7 +26,7 @@
 
 		<!-- Versions -->
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-		<ApplicationVersion>6</ApplicationVersion>
+		<ApplicationVersion>1</ApplicationVersion>
 
 		<NeutralLanguage>en-US</NeutralLanguage>
 
@@ -36,6 +36,8 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
+
+		<MauiEnableXamlCBindingWithSourceCompilation>true</MauiEnableXamlCBindingWithSourceCompilation>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Conference.Maui/MauiProgram.cs
+++ b/src/Conference.Maui/MauiProgram.cs
@@ -22,8 +22,6 @@ public static class MauiProgram
             })
             .UseMauiCommunityToolkit();
 
-        // TODO I don't think HttpClientFactory is great for mobile...?
-        //builder.Services.AddHttpClient();
         builder.Services.AddSingleton<IEventDataService, SessionizeService>();
         builder.Services.AddSingleton<ISponsorService, SponsorService>();
 

--- a/src/Conference.Maui/Models/Session.cs
+++ b/src/Conference.Maui/Models/Session.cs
@@ -34,6 +34,9 @@ public class Session
         [JsonIgnore]
         public List<Speaker> Speakers { get; set; } = [];
 
+        [JsonIgnore]
+        public string SpeakerProfilePicture => Speakers?.FirstOrDefault()?.ProfilePicture ?? string.Empty;
+
         [JsonPropertyName("categoryItems")]
         public List<object> CategoryItems { get; set; } = [];
 

--- a/src/Conference.Maui/Pages/SchedulePage.xaml
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml
@@ -25,7 +25,7 @@
 
                     <Grid ColumnSpacing="16">
                         <Grid.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:ScheduleViewModel}}, Path=GoToSessionDetailsCommand}" CommandParameter="{Binding .}" />
+                            <TapGestureRecognizer Command="{Binding x:DataType='viewmodels:ScheduleViewModel', Source={RelativeSource AncestorType={x:Type viewmodels:ScheduleViewModel}}, Path=GoToSessionDetailsCommand}" CommandParameter="{Binding .}" />
                         </Grid.GestureRecognizers>
 
                         <Grid.ColumnDefinitions>
@@ -44,7 +44,7 @@
                             CornerRadius="40"
                             HeightRequest="80"
                             HorizontalOptions="Center"
-                            ImageSource="{Binding Speakers[0].ProfilePicture}"
+                            ImageSource="{Binding SpeakerProfilePicture}"
                             VerticalOptions="Start"
                             WidthRequest="80" />
 

--- a/src/Conference.Maui/Pages/SessionDetailsPage.xaml
+++ b/src/Conference.Maui/Pages/SessionDetailsPage.xaml
@@ -14,7 +14,7 @@
                 <DataTemplate x:DataType="models:Speaker">
                     <VerticalStackLayout>
                         <VerticalStackLayout.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:SessionDetailsViewModel}}, Path=GoToSpeakerDetailsCommand}" CommandParameter="{Binding .}" />
+                            <TapGestureRecognizer Command="{Binding x:DataType='viewmodels:SessionDetailsViewModel', Source={RelativeSource AncestorType={x:Type viewmodels:SessionDetailsViewModel}}, Path=GoToSpeakerDetailsCommand}" CommandParameter="{Binding .}" />
                         </VerticalStackLayout.GestureRecognizers>
                         
                         <toolkit:AvatarView ImageSource="{Binding ProfilePicture}"

--- a/src/Conference.Maui/Pages/SpeakersPage.xaml
+++ b/src/Conference.Maui/Pages/SpeakersPage.xaml
@@ -13,7 +13,7 @@
             <DataTemplate x:DataType="models:Speaker">
                 <Grid ColumnSpacing="16" Margin="10">
                     <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:SpeakersViewModel}}, Path=GoToSpeakerDetailsCommand}" CommandParameter="{Binding .}" />
+                        <TapGestureRecognizer Command="{Binding x:DataType='viewmodels:SpeakersViewModel', Source={RelativeSource AncestorType={x:Type viewmodels:SpeakersViewModel}}, Path=GoToSpeakerDetailsCommand}" CommandParameter="{Binding .}" />
                     </Grid.GestureRecognizers>
 
                     <Grid.ColumnDefinitions>

--- a/src/Conference.Maui/Pages/SponsorsPage.xaml
+++ b/src/Conference.Maui/Pages/SponsorsPage.xaml
@@ -28,7 +28,7 @@
             <DataTemplate x:DataType="models:Sponsor">
                 <Grid Margin="10" ColumnSpacing="16">
                     <Grid.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:SponsorsViewModel}}, Path=OpenSponsorWebsiteCommand}" CommandParameter="{Binding .}" />
+                        <TapGestureRecognizer Command="{Binding x:DataType='viewmodels:SponsorsViewModel', Source={RelativeSource AncestorType={x:Type viewmodels:SponsorsViewModel}}, Path=OpenSponsorWebsiteCommand}" CommandParameter="{Binding .}" />
                     </Grid.GestureRecognizers>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="80" />


### PR DESCRIPTION
This caused a crash on iOS in release mode. Note to self: don't do `{Binding Speakers[0].ProfilePicture}`.