### PR TITLE
Support for multi-day events

### DIFF
--- a/src/Conference.Maui/Conference.Maui.csproj
+++ b/src/Conference.Maui/Conference.Maui.csproj
@@ -69,6 +69,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
 		<PackageReference Include="Plugin.Maui.SwipeCardView" Version="1.0.0-preview1" />
 		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+		<PackageReference Include="Syncfusion.Maui.Toolkit" Version="1.0.5" />
 	</ItemGroup>
 
 	<!-- Localization -->

--- a/src/Conference.Maui/MauiProgram.cs
+++ b/src/Conference.Maui/MauiProgram.cs
@@ -5,6 +5,7 @@ using Conference.Maui.Services;
 using Conference.Maui.ViewModels;
 using Microsoft.Extensions.Logging;
 using Plugin.Maui.SwipeCardView;
+using Syncfusion.Maui.Toolkit.Hosting;
 
 namespace Conference.Maui;
 
@@ -22,7 +23,8 @@ public static class MauiProgram
                 fonts.AddFont("Poppins-SemiBold.ttf", "PoppinsSemibold");
             })
             .UseMauiCommunityToolkit()
-            .UseSwipeCardView(); // Add SwipeCardView initialization
+            .UseSwipeCardView() // Add SwipeCardView initialization
+            .ConfigureSyncfusionToolkit();
 
         // Register services
         builder.Services.AddSingleton<IEventDataService, SessionizeService>();

--- a/src/Conference.Maui/Models/DaySchedule.cs
+++ b/src/Conference.Maui/Models/DaySchedule.cs
@@ -1,0 +1,10 @@
+using System.Collections.ObjectModel;
+
+namespace Conference.Maui.Models;
+
+public class DaySchedule
+{
+    public DateTime Date { get; set; }
+    public string TabTitle { get; set; } = string.Empty;
+    public ObservableCollection<Session> Sessions { get; set; } = [];
+}

--- a/src/Conference.Maui/Pages/SchedulePage.xaml
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml
@@ -6,85 +6,101 @@
     xmlns:controls="clr-namespace:Conference.Maui.Controls"
     xmlns:localization="clr-namespace:Conference.Maui.Resources.Strings"
     xmlns:models="clr-namespace:Conference.Maui.Models"
+    xmlns:syncfusion="clr-namespace:Syncfusion.Maui.Toolkit.TabView;assembly=Syncfusion.Maui.Toolkit"
     xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
     xmlns:viewmodels="clr-namespace:Conference.Maui.ViewModels"
     Title="{x:Static localization:Strings.SchedulePageTitle}"
     x:DataType="viewmodels:ScheduleViewModel">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <!-- Session Data Template for reuse -->
+            <DataTemplate x:Key="SessionTemplate" x:DataType="models:Session">
+                <Border
+                    Padding="10"
+                    Stroke="Black"
+                    StrokeShape="RoundRectangle 20"
+                    StrokeThickness="1">
+
+                    <Grid ColumnSpacing="16">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding x:DataType='viewmodels:ScheduleViewModel', Source={RelativeSource AncestorType={x:Type viewmodels:ScheduleViewModel}}, Path=GoToSessionDetailsCommand}" CommandParameter="{Binding .}" />
+                        </Grid.GestureRecognizers>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="80" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="60" />
+                            <RowDefinition Height="60" />
+                            <RowDefinition Height="20" />
+                        </Grid.RowDefinitions>
+
+                        <toolkit:AvatarView
+                            Grid.RowSpan="3"
+                            Grid.Column="0"
+                            CornerRadius="40"
+                            HeightRequest="80"
+                            HorizontalOptions="Center"
+                            ImageSource="{Binding SpeakerProfilePicture}"
+                            VerticalOptions="Start"
+                            WidthRequest="80" />
+
+                        <Label
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            FontFamily="PoppinsSemibold"
+                            FontSize="20"
+                            LineBreakMode="TailTruncation"
+                            MaxLines="2"
+                            Text="{Binding Title}" />
+
+                        <Label
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            LineBreakMode="TailTruncation"
+                            MaxLines="3"
+                            Text="{Binding Description}"
+                            TextColor="{StaticResource Gray400}" />
+
+                        <Label Grid.Row="2" Grid.Column="1">
+                            <Label.FormattedText>
+                                <FormattedString>
+                                    <Span Text="{Binding Room}" TextColor="{StaticResource Primary}" />
+
+                                    <Span
+                                        FontAttributes="Bold"
+                                        Text=" · "
+                                        TextColor="{StaticResource Gray400}" />
+
+                                    <Span Text="{Binding StartsAt, StringFormat='{0:HH:mm}'}" TextColor="{StaticResource Gray200}" />
+                                </FormattedString>
+                            </Label.FormattedText>
+                        </Label>
+                    </Grid>
+                </Border>
+            </DataTemplate>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <Grid>
-        <CollectionView Margin="10" ItemsSource="{Binding Sessions}">
+        <!-- Show TabView only if there are multiple days -->
+        <syncfusion:SfTabView 
+            x:Name="tabView"
+            EnableSwiping="True"
+            IsVisible="{Binding ShowTabs}"
+            BackgroundColor="{StaticResource White}">
+        </syncfusion:SfTabView>
+
+        <!-- Show regular CollectionView if there's only one day -->
+        <CollectionView 
+            Margin="10" 
+            ItemsSource="{Binding Sessions}"
+            ItemTemplate="{StaticResource SessionTemplate}"
+            IsVisible="{Binding ShowTabs, Converter={StaticResource InvertedBoolConverter}}">
             <CollectionView.ItemsLayout>
                 <LinearItemsLayout ItemSpacing="5" Orientation="Vertical" />
-
             </CollectionView.ItemsLayout>
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="models:Session">
-                    <Border
-                        Padding="10"
-                        Stroke="Black"
-                        StrokeShape="RoundRectangle 20"
-                        StrokeThickness="1">
-
-
-                        <Grid ColumnSpacing="16">
-                            <Grid.GestureRecognizers>
-                                <TapGestureRecognizer Command="{Binding x:DataType='viewmodels:ScheduleViewModel', Source={RelativeSource AncestorType={x:Type viewmodels:ScheduleViewModel}}, Path=GoToSessionDetailsCommand}" CommandParameter="{Binding .}" />
-                            </Grid.GestureRecognizers>
-
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="80" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="60" />
-                                <RowDefinition Height="60" />
-                                <RowDefinition Height="20" />
-                            </Grid.RowDefinitions>
-
-                            <toolkit:AvatarView
-                                Grid.RowSpan="3"
-                                Grid.Column="0"
-                                CornerRadius="40"
-                                HeightRequest="80"
-                                HorizontalOptions="Center"
-                                ImageSource="{Binding SpeakerProfilePicture}"
-                                VerticalOptions="Start"
-                                WidthRequest="80" />
-
-                            <Label
-                                Grid.Row="0"
-                                Grid.Column="1"
-                                FontFamily="PoppinsSemibold"
-                                FontSize="20"
-                                LineBreakMode="TailTruncation"
-                                MaxLines="2"
-                                Text="{Binding Title}" />
-
-                            <Label
-                                Grid.Row="1"
-                                Grid.Column="1"
-                                LineBreakMode="TailTruncation"
-                                MaxLines="3"
-                                Text="{Binding Description}"
-                                TextColor="{StaticResource Gray400}" />
-
-                            <Label Grid.Row="2" Grid.Column="1">
-                                <Label.FormattedText>
-                                    <FormattedString>
-                                        <Span Text="{Binding Room}" TextColor="{StaticResource Primary}" />
-
-                                        <Span
-                                            FontAttributes="Bold"
-                                            Text=" · "
-                                            TextColor="{StaticResource Gray400}" />
-
-                                        <Span Text="{Binding StartsAt, StringFormat='{0:dddd, HH:mm}'}" TextColor="{StaticResource Gray200}" />
-                                    </FormattedString>
-                                </Label.FormattedText>
-                            </Label>
-                        </Grid>
-                    </Border>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
         </CollectionView>
 
         <controls:FloatingButton

--- a/src/Conference.Maui/Pages/SchedulePage.xaml.cs
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml.cs
@@ -1,4 +1,7 @@
 using Conference.Maui.ViewModels;
+using Conference.Maui.Models;
+using Syncfusion.Maui.Toolkit.TabView;
+using System.Collections.ObjectModel;
 
 namespace Conference.Maui.Pages;
 
@@ -17,5 +20,42 @@ public partial class SchedulePage : ContentPage
     protected override async void OnNavigatedTo(NavigatedToEventArgs args)
     {
         await _viewModel.LoadEventData();
+        CreateTabs();
+    }
+
+    private void CreateTabs()
+    {
+        if (_viewModel.ShowTabs)
+        {
+            tabView.Items.Clear();
+            
+            foreach (var daySchedule in _viewModel.ScheduleDays)
+            {
+                var tabItem = new SfTabItem
+                {
+                    Header = daySchedule.TabTitle,
+                    Content = CreateTabContent(daySchedule.Sessions)
+                };
+                
+                tabView.Items.Add(tabItem);
+            }
+        }
+    }
+
+    private View CreateTabContent(ObservableCollection<Session> sessions)
+    {
+        var collectionView = new CollectionView
+        {
+            Margin = new Thickness(10),
+            ItemsSource = sessions,
+            ItemTemplate = (DataTemplate)Resources["SessionTemplate"]
+        };
+
+        collectionView.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+        {
+            ItemSpacing = 5
+        };
+
+        return collectionView;
     }
 }

--- a/src/Conference.Maui/Pages/SchedulePage.xaml.cs
+++ b/src/Conference.Maui/Pages/SchedulePage.xaml.cs
@@ -25,10 +25,15 @@ public partial class SchedulePage : ContentPage
 
     private void CreateTabs()
     {
+        if (tabView is null)
+        {
+            return;
+        }
+        
         if (_viewModel.ShowTabs)
         {
             tabView.Items.Clear();
-            
+
             foreach (var daySchedule in _viewModel.ScheduleDays)
             {
                 var tabItem = new SfTabItem
@@ -36,7 +41,7 @@ public partial class SchedulePage : ContentPage
                     Header = daySchedule.TabTitle,
                     Content = CreateTabContent(daySchedule.Sessions)
                 };
-                
+
                 tabView.Items.Add(tabItem);
             }
         }
@@ -44,16 +49,15 @@ public partial class SchedulePage : ContentPage
 
     private View CreateTabContent(ObservableCollection<Session> sessions)
     {
-        var collectionView = new CollectionView
+        CollectionView collectionView = new()
         {
             Margin = new Thickness(10),
             ItemsSource = sessions,
-            ItemTemplate = (DataTemplate)Resources["SessionTemplate"]
-        };
-
-        collectionView.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
-        {
-            ItemSpacing = 5
+            ItemTemplate = (DataTemplate)Resources["SessionTemplate"],
+            ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+            {
+                ItemSpacing = 5
+            }
         };
 
         return collectionView;

--- a/src/Conference.Maui/ViewModels/ScheduleViewModel.cs
+++ b/src/Conference.Maui/ViewModels/ScheduleViewModel.cs
@@ -12,6 +12,10 @@ public partial class ScheduleViewModel(IEventDataService eventDataService) : Obs
     private readonly IEventDataService _eventService = eventDataService;
 
     public ObservableCollection<Session> Sessions { get; set; } = [];
+    public ObservableCollection<DaySchedule> ScheduleDays { get; set; } = [];
+
+    [ObservableProperty]
+    private bool showTabs;
 
     public async Task LoadEventData()
     {
@@ -21,6 +25,32 @@ public partial class ScheduleViewModel(IEventDataService eventDataService) : Obs
         foreach (var session in sessions)
         {
             Sessions.Add(session);
+        }
+
+        // Group sessions by day
+        GroupSessionsByDay();
+    }
+
+    private void GroupSessionsByDay()
+    {
+        ScheduleDays.Clear();
+        
+        var groupedSessions = Sessions
+            .GroupBy(s => s.StartsAt.Date)
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        ShowTabs = groupedSessions.Count > 1;
+
+        foreach (var group in groupedSessions)
+        {
+            var daySchedule = new DaySchedule
+            {
+                Date = group.Key,
+                TabTitle = $"{group.Key:dddd}, {group.Key:MMM dd}",
+                Sessions = new ObservableCollection<Session>(group.OrderBy(s => s.StartsAt))
+            };
+            ScheduleDays.Add(daySchedule);
         }
     }
 


### PR DESCRIPTION
Adds tabs when the data contains multiple days and the event is a multiple day event.

If its only a single day it doesn't show the tab bar.

The tab bar shows the day and date (month + day)